### PR TITLE
Adding support for object return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1
+
+Adding support for object return.
+
 # 0.4.0
 
 Migrate to config.schema

--- a/actions/search.body.yaml
+++ b/actions/search.body.yaml
@@ -58,4 +58,8 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
+  return_object:
+    default: false
+    description: Return object as result instead of stdout.
+    type: boolean
 runner_type: run-python

--- a/actions/search.py
+++ b/actions/search.py
@@ -16,6 +16,7 @@ class SearchRunner(ESBaseAction):
     def __init__(self, config=None):
         super(SearchRunner, self).__init__(config=config)
         self._iselector = None
+        self._return_object = False
 
     @property
     def iselector(self):
@@ -37,10 +38,12 @@ class SearchRunner(ESBaseAction):
         self.config = EasyDict(kwargs)
         self.set_up_logging()
 
+        self._return_object = kwargs.get('return_object', False)
+
         if action.endswith('.q'):
-            self.simple_search()
+            return self.simple_search()
         else:
-            self.full_search()
+            return self.full_search()
 
     def simple_search(self):
         """Perform URI-based request search.
@@ -55,7 +58,11 @@ class SearchRunner(ESBaseAction):
             logger.error(e.message)
             sys.exit(2)
 
-        self._pp_exit(result)
+        if self._return_object:
+            return True, result
+        else:
+            self._pp_exit(result)
+            return None
 
     def full_search(self):
         """Perform search using Query DSL.
@@ -69,7 +76,11 @@ class SearchRunner(ESBaseAction):
             logger.error(e.message)
             sys.exit(2)
 
-        self._pp_exit(result)
+        if self._return_object:
+            return True, result
+        else:
+            self._pp_exit(result)
+            return None
 
     def _pp_exit(self, data):
         """Print Elastcsearch JSON response and exit.

--- a/actions/search.q.yaml
+++ b/actions/search.q.yaml
@@ -97,4 +97,8 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
+  return_object:
+    default: false
+    description: Return object as result instead of stdout.
+    type: boolean
 runner_type: run-python

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - elasticsearch
   - curator
   - databases
-version : 0.4.0
+version : 0.4.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Instead of simply returning a string of the output this PR adds support for returning it as an object if desired.