### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.4.2
 
 Adding http_auth and use_ssl support on count_sensor.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Curator based actions
 
 These actions operate similar to [curator](http://www.elastic.co/guide/en/elasticsearch/client/curator/current/) for Elasticsearch.

--- a/actions/indices.alias.yaml
+++ b/actions/indices.alias.yaml
@@ -91,4 +91,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.allocation.yaml
+++ b/actions/indices.allocation.yaml
@@ -87,4 +87,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.bloom.yaml
+++ b/actions/indices.bloom.yaml
@@ -87,4 +87,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.close.yaml
+++ b/actions/indices.close.yaml
@@ -83,4 +83,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.delete.yaml
+++ b/actions/indices.delete.yaml
@@ -91,4 +91,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.open.yaml
+++ b/actions/indices.open.yaml
@@ -83,4 +83,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.optimize.yaml
+++ b/actions/indices.optimize.yaml
@@ -91,4 +91,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.replicas.yaml
+++ b/actions/indices.replicas.yaml
@@ -87,4 +87,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.show.yaml
+++ b/actions/indices.show.yaml
@@ -83,4 +83,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/indices.snapshot.yaml
+++ b/actions/indices.snapshot.yaml
@@ -108,4 +108,4 @@ parameters:
     default: true
     description: Wait for snapshot to complete before returning.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/lib/static_metagen.py
+++ b/actions/lib/static_metagen.py
@@ -62,7 +62,7 @@ class StaticMetagen(object):
                 "default": False
             }
         },
-        "runner_type": "run-python",
+        "runner_type": "python-script",
         "description": "Run a Meta Action through a generic Runner.",
         "enabled": True,
         "entry_point": "curator_runner.py"}

--- a/actions/search.body.yaml
+++ b/actions/search.body.yaml
@@ -62,4 +62,4 @@ parameters:
     default: false
     description: Return object as result instead of stdout.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/search.q.yaml
+++ b/actions/search.q.yaml
@@ -101,4 +101,4 @@ parameters:
     default: false
     description: Return object as result instead of stdout.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/snapshots.delete.yaml
+++ b/actions/snapshots.delete.yaml
@@ -95,4 +95,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/actions/snapshots.show.yaml
+++ b/actions/snapshots.show.yaml
@@ -87,4 +87,4 @@ parameters:
     default: false
     description: Connect to Elasticsearch through SSL.
     type: boolean
-runner_type: run-python
+runner_type: python-script

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - elasticsearch
   - curator
   - databases
-version : 0.4.2
+version : 0.5.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.