### PR TITLE
Change default log_level from warn to WARNING

### DIFF
--- a/actions/cluster.cluster_routing.yaml
+++ b/actions/cluster.cluster_routing.yaml
@@ -55,8 +55,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/curator_runner.py
+++ b/actions/curator_runner.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class CuratorRunner(CuratorAction):
 
-    def run(self, action=None, log_level='warn', dry_run=False, operation_timeout=600, **kwargs):
+    def run(self, action=None, log_level='WARNING', dry_run=False, operation_timeout=600, **kwargs):
         """Curator based action entry point
         """
         self._action = action

--- a/actions/indices.alias.yaml
+++ b/actions/indices.alias.yaml
@@ -62,8 +62,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.allocation.yaml
+++ b/actions/indices.allocation.yaml
@@ -64,8 +64,8 @@ parameters:
     required: true
     type: string
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.close.yaml
+++ b/actions/indices.close.yaml
@@ -58,8 +58,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.create_index.yaml
+++ b/actions/indices.create_index.yaml
@@ -58,8 +58,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.delete_indices.yaml
+++ b/actions/indices.delete_indices.yaml
@@ -55,8 +55,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.forcemerge.yaml
+++ b/actions/indices.forcemerge.yaml
@@ -58,8 +58,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.index_settings.yaml
+++ b/actions/indices.index_settings.yaml
@@ -62,8 +62,8 @@ parameters:
     description: A dictionary structure with one or more index settings to change.
     type: object
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.open.yaml
+++ b/actions/indices.open.yaml
@@ -55,8 +55,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.optimize.yaml
+++ b/actions/indices.optimize.yaml
@@ -59,8 +59,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.reindex.yaml
+++ b/actions/indices.reindex.yaml
@@ -55,8 +55,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.replicas.yaml
+++ b/actions/indices.replicas.yaml
@@ -59,8 +59,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.rollover.yaml
+++ b/actions/indices.rollover.yaml
@@ -63,8 +63,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.show.yaml
+++ b/actions/indices.show.yaml
@@ -55,8 +55,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.shrink.yaml
+++ b/actions/indices.shrink.yaml
@@ -68,8 +68,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/indices.snapshot.yaml
+++ b/actions/indices.snapshot.yaml
@@ -62,8 +62,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/lib/curator_actions.yaml
+++ b/actions/lib/curator_actions.yaml
@@ -241,10 +241,8 @@
         required: true
       add:
         description: "Add to alias."
-        type: "object"
       remove:
         description: "Remove from alias rather than add."
-        type: "object"
       extra_settings:
         description: "The extra_settings option allows the addition of extra settings with the add directive. These settings are ignored for remove."
         type: "object"

--- a/actions/lib/static_metagen.py
+++ b/actions/lib/static_metagen.py
@@ -121,6 +121,7 @@ class StaticMetagen(object):
                 yield alias_manifest
             yield manifest
 
+
 metagen = StaticMetagen()
 metagen.generate_from_file('lib/curator_actions.yaml')
 # print yaml.dump(metagen.meta_actions)

--- a/actions/lib/static_metagen.py
+++ b/actions/lib/static_metagen.py
@@ -52,9 +52,9 @@ class StaticMetagen(object):
                 "type": "string"
             },
             "log_level": {
-                "description": "Log level [critical|error|warning|info|debug].",
+                "description": "Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].",
                 "type": "string",
-                "default": "warn"
+                "default": "WARNING"
             },
             "dry_run": {
                 "description": "Do not perform any changes.",

--- a/actions/snapshots.delete_snapshots.yaml
+++ b/actions/snapshots.delete_snapshots.yaml
@@ -50,8 +50,8 @@ parameters:
       curator will exit with code 1.
     type: boolean
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/snapshots.restore.yaml
+++ b/actions/snapshots.restore.yaml
@@ -76,8 +76,8 @@ parameters:
       type: string
     type: array
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/actions/snapshots.show.yaml
+++ b/actions/snapshots.show.yaml
@@ -50,8 +50,8 @@ parameters:
       curator will exit with code 1.
     type: boolean
   log_level:
-    default: warn
-    description: Log level [critical|error|warning|info|debug].
+    default: WARNING
+    description: Log level [CRITICAL|ERROR|WARNING|INFO|DEBUG].
     type: string
   master_only:
     default: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - elasticsearch
   - curator
   - databases
-version: 1.0.0
+version: 1.0.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
The error received on all elasticsearch actions when run with st2 `2.5.1` was:

```
ERROR: 400 Client Error: Bad Request
MESSAGE: 'warn' is not one of ['AUDIT', 'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'] for url: http://127.0.0.1:9101/v1/executions
```

st2 `2.5.1` added `log_level`, which conflicted with the existing elasticsearch `log_level` found in the pack. This PR fixes the above error.

Also backing out an accidental change to `curator_actions.yaml` (removed `type: "object"`, since the type should be the default `string`). @Mierdin and I both agree that types should be explicit - a future PR shall address this.