### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 2.0.1
+
+* Fixed CI errors
+
 # 2.0.0
 
 * Drop Python 2.7 support

--- a/actions/lib/static_metagen.py
+++ b/actions/lib/static_metagen.py
@@ -90,7 +90,7 @@ class StaticMetagen(object):
         if meta_file is None:
             return None
         with open(meta_file) as fh:
-            actions = yaml.load(fh.read())
+            actions = yaml.safe_load(fh.read())
         for manifest in self._merge_actions(actions):
             fh = open('{0}.yaml'.format(manifest['name']), 'w')
             fh.write('---\n')

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - elasticsearch
   - curator
   - databases
-version: 2.0.0
+version: 2.0.1
 author : StackStorm, Inc.
 email : info@stackstorm.com
 python_versions:

--- a/tests/test_action_curator_runner.py
+++ b/tests/test_action_curator_runner.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from curator_runner import CuratorRunner
 
 class TestCuratorRunner(unittest.TestCase):

--- a/tests/test_action_curator_runner.py
+++ b/tests/test_action_curator_runner.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 from curator_runner import CuratorRunner
 
+
 class TestCuratorRunner(unittest.TestCase):
 
     @patch('curator_runner.CuratorAction.__init__', return_value=None)

--- a/tests/test_action_curator_runner.py
+++ b/tests/test_action_curator_runner.py
@@ -60,5 +60,6 @@ class TestCuratorRunner(unittest.TestCase):
         mock_set_up_logging.assert_called_once()
         mock_do_command.assert_called_once()
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_action_curator_runner.py
+++ b/tests/test_action_curator_runner.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from curator_runner import CuratorRunner
+
+class TestCuratorRunner(unittest.TestCase):
+
+    @patch('curator_runner.CuratorAction.__init__', return_value=None)
+    @patch('curator_runner.CuratorRunner.set_up_logging')
+    @patch('curator_runner.CuratorRunner.do_command')
+    def test_run_with_host_and_port(self, mock_do_command, mock_set_up_logging,
+                                    mock_curator_action_init):
+        # Arrange
+        runner = CuratorRunner()
+        runner.config = {'host': 'localhost', 'port': 9200}
+        action = 'test_action'
+        log_level = 'INFO'
+        dry_run = True
+        operation_timeout = 300
+        mock_curator_action_init.return_value = None
+
+        # Act
+        runner.run(action=action, log_level=log_level, dry_run=dry_run,
+                   operation_timeout=operation_timeout)
+
+        # Assert
+        self.assertEqual(runner._action, action)
+        self.assertEqual(runner.config['timeout'], operation_timeout)
+        self.assertEqual(runner.config['log_level'], log_level)
+        self.assertEqual(runner.config['dry_run'], dry_run)
+        self.assertEqual(runner.config['host'], 'localhost')
+        self.assertEqual(runner.config['port'], 9200)
+        mock_set_up_logging.assert_called_once()
+        mock_do_command.assert_called_once()
+
+    @patch('curator_runner.CuratorAction.__init__', return_value=None)
+    @patch('curator_runner.CuratorRunner.set_up_logging')
+    @patch('curator_runner.CuratorRunner.do_command')
+    def test_run_without_host_and_port(self, mock_do_command, mock_set_up_logging,
+                                       mock_curator_action_init):
+        # Arrange
+        runner = CuratorRunner()
+        runner.config = {}
+        action = 'test_action'
+        log_level = 'INFO'
+        dry_run = True
+        operation_timeout = 300
+        mock_curator_action_init.return_value = None
+
+        # Act
+        runner.run(action=action, log_level=log_level, dry_run=dry_run,
+                   operation_timeout=operation_timeout)
+
+        # Assert
+        self.assertEqual(runner._action, action)
+        self.assertEqual(runner.config['timeout'], operation_timeout)
+        self.assertEqual(runner.config['log_level'], log_level)
+        self.assertEqual(runner.config['dry_run'], dry_run)
+        self.assertNotIn('host', runner.config)
+        self.assertNotIn('port', runner.config)
+        mock_set_up_logging.assert_called_once()
+        mock_do_command.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed files to work with latest CI updates. As of pyyaml 5.4 (the current version being installed is 6.0.2) a `Loader` param is required to pass into the `load` function. `safe_load` runs load with the `yaml.SafeLoader` param as the `Loader`

https://stackoverflow.com/a/63916315